### PR TITLE
fix(): error path too long for win build

### DIFF
--- a/scripts/winstaller.js
+++ b/scripts/winstaller.js
@@ -4,8 +4,9 @@ const winstaller = require('electron-winstaller')
 const { version } = require('../package.json')
 
 winstaller.createWindowsInstaller({
-  appDirectory: './release-builds/Ara File Manager-win32-x64/',
-  outputDirectory: './release-builds/winstalled',
+  // Drag ./release-builds/Ara File Manager-win32-x64/ to the Desktop
+  appDirectory: 'C:/Users/Admin/Desktop/Ara File Manager-win32-x64/',
+  outputDirectory: 'C:/Users/Admin/Desktop/winstalled',
   authors: 'Ara blocks',
   exe: `Ara File Manager.exe`,
   iconUrl: 'https://s3.amazonaws.com/ara-prod-media/file-manager/ara_prod.ico',


### PR DESCRIPTION
Fixes error when running script `build-prod-windows`:

```
Attempting to build package from 'ara-file-manager.nuspec'.
The specified path, file name, or both are too long. The fully qualified file name must be less than 260 characters, and the directory name must be less than 248 characters.
```