### PR TITLE
fix: asar smaller faster and avoids windows long path bug

### DIFF
--- a/scripts/build-dev-mac.sh
+++ b/scripts/build-dev-mac.sh
@@ -10,6 +10,7 @@ echo 'Using electron-packager, should take around 1 minute...'
 --arch=x64 \
 --icon=./build/icons/mac/ara_dev.icns \
 --prune=true \
+--asar \
 --out=release-builds \
 --app-bundle-id=\"com.ara.one.araFileManager\"
 echo '...done. Now release-builds has a darwin folder with a .app folder inside'

--- a/scripts/build-dev-win.sh
+++ b/scripts/build-dev-win.sh
@@ -10,6 +10,7 @@ echo 'Using electron-packager, may take around 5 minutes...'
 --arch=x64 \
 --icon=./build/icons/windows/ara_dev.ico \
 --prune=true \
+--asar \
 --out=release-builds \
 --protocol=ara
 echo '...done. Now release-builds has a win32 folder with .exe and .dll files inside'

--- a/scripts/build-prod-mac.sh
+++ b/scripts/build-prod-mac.sh
@@ -14,6 +14,7 @@ echo 'Using electron-packager, should take around 1 minute...'
 --arch=x64 \
 --icon=./build/icons/mac/ara.icns \
 --prune=true \
+--asar \
 --out=release-builds \
 --app-bundle-id=\"com.ara.one.araFileManager\"
 echo '...done. Now release-builds has a darwin folder with a .app folder inside'

--- a/scripts/build-prod-win.sh
+++ b/scripts/build-prod-win.sh
@@ -22,6 +22,7 @@ echo 'Using electron-packager, may take around 5 minutes...'
 --arch=x64 \
 --icon=./build/icons/windows/ara_prod.ico \
 --prune=true \
+--asar \
 --out=release-builds
 echo '...done. Now release-builds has a win32 folder with .exe and .dll files inside'
 echo ''
@@ -30,7 +31,7 @@ echo ''
 sed -i.bak s/"const IS_PRODUCTION = "[[:print:]]*/"const IS_PRODUCTION = false"/ "$ANALYTICS_CONSTANTS"
 
 # Installer
-echo 'Using electron-winstaller, we have seen this take around 90 minutes...'
+echo 'Using electron-winstaller, may take around 5 minutes...'
 # There's no progress output, but open Task Manager to watch NuGet and then 7zip heavily use the CPU
 # Run our script that uses electron-winstaller, telling it to output some debug messages
 DEBUG=electron-windows-installer:main node ./scripts/build-prod-winstaller.js


### PR DESCRIPTION
These changes add the flag for asar to mac and win dev and prod build scripts.

asar is a common default for Electron apps and electron-packager.

With this change, paths too long for many Windows apps (including Squirrel) get hidden inside the asar, and the windows build works again.

Packaging with asar lets setup place several hundred rather than several thousand files on the user's disk, increasing the speed and reliability of creating and running installation packages for both mac and windows.

Several months ago, team avoided asar believing that packaging that way may negatively impact UI speed and responsiveness, but @zootella and @bplaster have tested the app with asar, and can't reproduce that behavior now.