### PR TITLE
fix(.ararc): steer clear of older utp-native

### DIFF
--- a/.ararc
+++ b/.ararc
@@ -38,3 +38,6 @@ server[] = "1.1.1.1"
 [network.dht]
 bootstrap[] = "discovery1.cafe.network:6881"
 bootstrap[] = "discovery1.ara.one:6881"
+
+[network.discovery.swarm]
+utp = false


### PR DESCRIPTION
Hi @jwerle this is the fix you suggested. @mahjiang and I believe it is preventing crashes when archiving is slow/unreliable. So, interested to know your thought on:

-should we make it the default for FM?
-is there a better way to prevent Ara modules from trying to use the older utp-native?