### PR TITLE
Show file manager version in Windows

### DIFF
--- a/browser/views/accountInfo.js
+++ b/browser/views/accountInfo.js
@@ -1,6 +1,6 @@
 const { events } = require('k')
 const Button = require('../components/button')
-const { clipboard } = require('electron')
+const { clipboard, shell, remote } = require('electron')
 const { emit } = require('../lib/tools/windowManagement')
 const DynamicTooltip = require('../components/dynamicTooltip')
 const TestnetBanner = require('../components/testnetBanner')
@@ -9,7 +9,6 @@ const styles = require('./styles/accountInfo')
 const { utils, windowManagement } = require('../lib/tools')
 const html = require('nanohtml')
 const Nanocomponent = require('nanocomponent')
-const { shell } = require('electron')
 
 class AccountInfo extends Nanocomponent {
   constructor(props) {
@@ -23,7 +22,8 @@ class AccountInfo extends Nanocomponent {
       ethBalance: account.ethBalance,
       faucetStatus: account.faucetStatus,
       network: application.network,
-      userDID: account.userDID
+      userDID: account.userDID,
+      appVersion: remote.app.getVersion()
     }
 
     this.children = {
@@ -151,6 +151,7 @@ class AccountInfo extends Nanocomponent {
         </div>
         <div class="${styles.appInfo} accountInfo-appInfo">
             ${utils.shouldShowBanner(props.network) ? html`<div>Note: Tokens will only work on testnet.</div>` : html``}
+          <p>Version ${props.appVersion}</p>
           <div class="link-holder">
             <a onclick=${toggleAnalyticsPermission}>
               ${props.analyticsPermission ? 'Disable Analytics' : 'Enable Analytics' }

--- a/package.json
+++ b/package.json
@@ -16,11 +16,11 @@
   "bugs": {
     "url": "https://github.com/arablocks/ara-file-manager/issues"
   },
-  "main": "boot",
+  "main": "boot/index.js",
   "network": "test",
   "scripts": {
     "postinstall": "sh ./scripts/postinstall.sh && electron-builder install-app-deps",
-    "start": "electron boot/index.js",
+    "start": "electron .",
     "dir": "electron-builder --dir",
     "build": "electron-builder",
     "clean": "sh ./scripts/clean.sh",


### PR DESCRIPTION
Small change to show the version from package.json at the bottom of the Account box.

Previously, there's no way to see the installed version in Windows.