### PR TITLE
feat(package.json): electron builder linux targets

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,6 +69,14 @@
       "perMachine": false,
       "createStartMenuShortcut": true,
       "createDesktopShortcut": true
+    },
+    "linux": {
+      "target": [
+        "AppImage",
+        "snap",
+        "pacman",
+        "zip"
+      ]
     }
   },
   "dependencies": {


### PR DESCRIPTION
@jwerle thanks for adding files for snapcraft, and linux builds for 1.1.1

This branch adds the "linux" target to package.json. These new lines, and a few others, should be all we need to get `$ npm run build` on linux to make linux binaries (as it already does on mac and windows)

But, I'll need your help testing both the build and the app